### PR TITLE
Collapseable plugin

### DIFF
--- a/ConfigurationManager/ConfigurationManager.cs
+++ b/ConfigurationManager/ConfigurationManager.cs
@@ -382,19 +382,26 @@ namespace ConfigurationManager
         {
             GUILayout.BeginVertical(GUI.skin.box);
             {
-                if (_showDebug)
-                    SettingFieldDrawer.DrawCenteredLabel(new GUIContent($"{plugin.Key.Name.TrimStart('!')} {plugin.Key.Version}", "GUID: " + plugin.Key.GUID));
-                else
-                    SettingFieldDrawer.DrawCenteredLabel($"{plugin.Key.Name.TrimStart('!')} {plugin.Key.Version}");
-
                 var seb = plugin.Select(x => x).First();
-                var showSetting = seb.ShowSetting;
-                var newShowSetting = GUILayout.Toggle(showSetting, "Show");
-                if(showSetting != newShowSetting)
+                bool buttonPressed;
+                if (_showDebug)
+                    buttonPressed = SettingFieldDrawer.DrawCollapseableButton(new GUIContent($"{plugin.Key.Name.TrimStart('!')} {plugin.Key.Version}", "GUID: " + plugin.Key.GUID), seb.IsCollapsed);
+                else
+                    buttonPressed = SettingFieldDrawer.DrawCollapseableButton($"{plugin.Key.Name.TrimStart('!')} {plugin.Key.Version}", seb.IsCollapsed);
+
+                if(buttonPressed)
                 {
-                    seb.ShowSetting = newShowSetting;
+                    if(seb.IsCollapsed == true)
+                    {
+                        seb.IsCollapsed = false;
+                    }
+                    else
+                    {
+                        seb.IsCollapsed = true;
+                    }
                 }
-                if (seb.ShowSetting)
+                if (!string.IsNullOrEmpty(_searchString)
+                    || !seb.IsCollapsed)
                 {
                     var categories = plugin
                     .Select(x => new { plugin = x, category = GetCategory(x) })

--- a/ConfigurationManager/ConfigurationManager.cs
+++ b/ConfigurationManager/ConfigurationManager.cs
@@ -382,24 +382,39 @@ namespace ConfigurationManager
 
         private void DrawSinglePlugin(IGrouping<BepInPlugin, SettingEntryBase> plugin)
         {
-            GUILayout.BeginVertical(GUI.skin.box);
-            {
-                if (_showDebug)
-                    SettingFieldDrawer.DrawCenteredLabel(new GUIContent($"{plugin.Key.Name.TrimStart('!')} {plugin.Key.Version}", "GUID: " + plugin.Key.GUID));
-                else
-                    SettingFieldDrawer.DrawCenteredLabel($"{plugin.Key.Name.TrimStart('!')} {plugin.Key.Version}");
+            GUILayout.BeginVertical(GUI.skin.box);            
+            var seb = plugin.Select(x => x).First();
+            bool buttonPressed;
+            if (_showDebug)
+                buttonPressed = SettingFieldDrawer.DrawCollapseableButton(new GUIContent($"{plugin.Key.Name.TrimStart('!')} {plugin.Key.Version}", "GUID: " + plugin.Key.GUID), seb.IsCollapsed);
+            else
+                buttonPressed = SettingFieldDrawer.DrawCollapseableButton($"{plugin.Key.Name.TrimStart('!')} {plugin.Key.Version}", seb.IsCollapsed);
 
+            if (buttonPressed)
+            {
+                if (seb.IsCollapsed == true)
+                {
+                    seb.IsCollapsed = false;
+                }
+                else
+                {
+                    seb.IsCollapsed = true;
+                }
+            }
+            if (!string.IsNullOrEmpty(SearchString)
+                || !seb.IsCollapsed)
+            {
                 var categories = plugin
-                    .Select(x => new { plugin = x, category = GetCategory(x) })
-                    .GroupBy(x => x.category.text)
-                    .OrderBy(x => string.Equals(x.Key, _keyboardShortcutsCategoryName.text, StringComparison.Ordinal))
-                    .ThenBy(x => x.Key).ToList();
+                .Select(x => new { plugin = x, category = GetCategory(x) })
+                .GroupBy(x => x.category.text)
+                .OrderBy(x => string.Equals(x.Key, _keyboardShortcutsCategoryName.text, StringComparison.Ordinal))
+                .ThenBy(x => x.Key).ToList();
 
                 foreach (var category in categories)
                 {
-                    if(!string.IsNullOrEmpty(category.Key))
+                    if (!string.IsNullOrEmpty(category.Key))
                     {
-                        if(!(_hideSingleSection.Value && categories.Count == 1))
+                        if (!(_hideSingleSection.Value && categories.Count == 1))
                             SettingFieldDrawer.DrawCenteredLabel(category.First().category);
                     }
 
@@ -409,6 +424,7 @@ namespace ConfigurationManager
                         GUILayout.Space(2);
                     }
                 }
+                
             }
             GUILayout.EndVertical();
         }

--- a/ConfigurationManager/ConfigurationManager.cs
+++ b/ConfigurationManager/ConfigurationManager.cs
@@ -307,16 +307,14 @@ namespace ConfigurationManager
             {
                 foreach (var plugin in _filteredSetings)
                 {
-                    var seb = plugin.Select(x => x).First();
-                    seb.IsCollapsed = false;
+                    plugin.Select(x => x).First().IsCollapsed = false;
                 }
             }
             if (collapseAll)
             {
                 foreach (var plugin in _filteredSetings)
                 {
-                    var seb = plugin.Select(x => x).First();
-                    seb.IsCollapsed = true;
+                    plugin.Select(x => x).First().IsCollapsed = true;
                 }
             }
         }

--- a/ConfigurationManager/ConfigurationManager.cs
+++ b/ConfigurationManager/ConfigurationManager.cs
@@ -377,7 +377,7 @@ namespace ConfigurationManager
                 BuildFilteredSettingList();
             }
         }
-
+        
         private void DrawSinglePlugin(IGrouping<BepInPlugin, SettingEntryBase> plugin)
         {
             GUILayout.BeginVertical(GUI.skin.box);
@@ -387,23 +387,33 @@ namespace ConfigurationManager
                 else
                     SettingFieldDrawer.DrawCenteredLabel($"{plugin.Key.Name.TrimStart('!')} {plugin.Key.Version}");
 
-                var categories = plugin
+                var seb = plugin.Select(x => x).First();
+                var showSetting = seb.ShowSetting;
+                var newShowSetting = GUILayout.Toggle(showSetting, "Show");
+                if(showSetting != newShowSetting)
+                {
+                    seb.ShowSetting = newShowSetting;
+                }
+                if (seb.ShowSetting)
+                {
+                    var categories = plugin
                     .Select(x => new { plugin = x, category = GetCategory(x) })
                     .GroupBy(x => x.category.text)
                     .OrderBy(x => string.Equals(x.Key, _keyboardShortcutsCategoryName.text, StringComparison.Ordinal))
                     .ThenBy(x => x.Key).ToList();
 
-                foreach (var category in categories)
-                {
-                    if (!string.IsNullOrEmpty(category.Key) && categories.Count > 1)
-                        SettingFieldDrawer.DrawCenteredLabel(category.First().category);
-
-                    foreach (var setting in category.OrderByDescending(x => x.plugin.Order).ThenBy(x => x.plugin.DispName))
+                    foreach (var category in categories)
                     {
-                        DrawSingleSetting(setting.plugin);
-                        GUILayout.Space(2);
+                        if (!string.IsNullOrEmpty(category.Key) && categories.Count > 1)
+                            SettingFieldDrawer.DrawCenteredLabel(category.First().category);
+
+                        foreach (var setting in category.OrderByDescending(x => x.plugin.Order).ThenBy(x => x.plugin.DispName))
+                        {
+                            DrawSingleSetting(setting.plugin);
+                            GUILayout.Space(2);
+                        }
                     }
-                }
+                }                
             }
             GUILayout.EndVertical();
         }

--- a/ConfigurationManager/ConfigurationManager.cs
+++ b/ConfigurationManager/ConfigurationManager.cs
@@ -76,6 +76,7 @@ namespace ConfigurationManager
         private readonly ConfigEntry<bool> _showSettings;
         private readonly ConfigEntry<BepInEx.Configuration.KeyboardShortcut> _keybind;
         private readonly ConfigEntry<bool> _hideSingleSection;
+        private readonly ConfigEntry<bool> _pluginConfigCollapsedDefault;
         private bool _showDebug;
         private string _searchString = string.Empty;
 
@@ -92,6 +93,7 @@ namespace ConfigurationManager
                 new ConfigDescription("The shortcut used to toggle the config manager window on and off.\n" +
                                       "The key can be overridden by a game-specific plugin if necessary, in that case this setting is ignored."));
             _hideSingleSection = Config.AddSetting("General", "Hide single sections", false, new ConfigDescription("Show section title for plugins with only one section"));
+            _pluginConfigCollapsedDefault = Config.AddSetting("General", "Plugin collapsed default", true, new ConfigDescription("If set to true plugins will be collapsed when opening the configuration manager window"));
         }
 
         /// <summary>
@@ -148,7 +150,7 @@ namespace ConfigurationManager
 
         private void BuildSettingList()
         {
-            SettingSearcher.CollectSettings(out var results, out var modsWithoutSettings, _showDebug);
+            SettingSearcher.CollectSettings(out var results, out var modsWithoutSettings, _showDebug, _pluginConfigCollapsedDefault.Value);
 
             _modsWithoutSettings = string.Join(", ", modsWithoutSettings.Select(x => x.TrimStart('!')).OrderBy(x => x).ToArray());
             _allSettings = results.ToList();

--- a/ConfigurationManager/ConfigurationManager.cs
+++ b/ConfigurationManager/ConfigurationManager.cs
@@ -273,6 +273,8 @@ namespace ConfigurationManager
                 if (string.IsNullOrEmpty(SearchString))
                     GUILayout.Label("Tip: You can left-click setting names on the left to see their descriptions.");
 
+                DrawExpandCollapseAll();
+
                 foreach (var plugin in _filteredSetings)
                     DrawSinglePlugin(plugin);
 
@@ -292,6 +294,31 @@ namespace ConfigurationManager
 
             if (!SettingFieldDrawer.DrawCurrentDropdown())
                 DrawTooltip(SettingWindowRect);
+        }
+
+        private void DrawExpandCollapseAll()
+        {
+            GUILayout.BeginHorizontal();
+            var expandAll = GUILayout.Button("Expand All", GUILayout.Width(100f));
+            var collapseAll = GUILayout.Button("Collapse All", GUILayout.Width(100f));
+            GUILayout.FlexibleSpace();
+            GUILayout.EndHorizontal();
+            if (expandAll)
+            {
+                foreach (var plugin in _filteredSetings)
+                {
+                    var seb = plugin.Select(x => x).First();
+                    seb.IsCollapsed = false;
+                }
+            }
+            if (collapseAll)
+            {
+                foreach (var plugin in _filteredSetings)
+                {
+                    var seb = plugin.Select(x => x).First();
+                    seb.IsCollapsed = true;
+                }
+            }
         }
 
         private void DrawWindowHeader()

--- a/ConfigurationManager/SettingEntryBase.cs
+++ b/ConfigurationManager/SettingEntryBase.cs
@@ -15,6 +15,9 @@ namespace ConfigurationManager
     /// </summary>
     public abstract class SettingEntryBase
     {
+        /// <summary>
+        /// Bool to allow collapseable UI for plugins
+        /// </summary>
         public bool IsCollapsed { get; internal set; }
 
         /// <summary>

--- a/ConfigurationManager/SettingEntryBase.cs
+++ b/ConfigurationManager/SettingEntryBase.cs
@@ -15,6 +15,8 @@ namespace ConfigurationManager
     /// </summary>
     public abstract class SettingEntryBase
     {
+        public bool ShowSetting { get; internal set; }
+
         /// <summary>
         /// List of values this setting can take
         /// </summary>

--- a/ConfigurationManager/SettingEntryBase.cs
+++ b/ConfigurationManager/SettingEntryBase.cs
@@ -15,7 +15,7 @@ namespace ConfigurationManager
     /// </summary>
     public abstract class SettingEntryBase
     {
-        public bool ShowSetting { get; internal set; }
+        public bool IsCollapsed { get; internal set; }
 
         /// <summary>
         /// List of values this setting can take

--- a/ConfigurationManager/SettingFieldDrawer.cs
+++ b/ConfigurationManager/SettingFieldDrawer.cs
@@ -103,7 +103,10 @@ namespace ConfigurationManager
 
         public static bool DrawCollapseableButton(GUIContent content, bool isCollapsed, params GUILayoutOption[] options)
         {
-            return DrawCollapseableButton(content.ToString(), isCollapsed, options);
+            GUILayout.BeginHorizontal(options);
+            var buttonPressed = GUILayout.Button(content, GUILayout.ExpandWidth(true));
+            GUILayout.EndHorizontal();
+            return buttonPressed;
         }
 
         public static bool DrawCurrentDropdown()

--- a/ConfigurationManager/SettingFieldDrawer.cs
+++ b/ConfigurationManager/SettingFieldDrawer.cs
@@ -88,6 +88,32 @@ namespace ConfigurationManager
             GUILayout.EndHorizontal();
         }
 
+        public static bool DrawCollapseableButton(string text, bool isCollapsed, params GUILayoutOption[] options)
+        {
+            GUILayout.BeginHorizontal(options);
+            string plusMinus = " [-]";
+            if (isCollapsed)
+            {
+                plusMinus = " [+]";
+            }
+            var x = GUILayout.Button(text + plusMinus, GUILayout.ExpandWidth(true));
+            GUILayout.EndHorizontal();
+            return x;
+        }
+
+        public static bool DrawCollapseableButton(GUIContent content, bool isCollapsed, params GUILayoutOption[] options)
+        {
+            GUILayout.BeginHorizontal(options);
+            string plusMinus = " [-]";
+            if (isCollapsed)
+            {
+                plusMinus = " [+]";
+            }
+            var x = GUILayout.Button(content + plusMinus, GUILayout.ExpandWidth(true));
+            GUILayout.EndHorizontal();
+            return x;
+        }
+
         public static bool DrawCurrentDropdown()
         {
             if (ComboBox.CurrentDropdownDrawer != null)

--- a/ConfigurationManager/SettingFieldDrawer.cs
+++ b/ConfigurationManager/SettingFieldDrawer.cs
@@ -96,22 +96,14 @@ namespace ConfigurationManager
             {
                 plusMinus = " [+]";
             }
-            var x = GUILayout.Button(text + plusMinus, GUILayout.ExpandWidth(true));
+            var buttonPressed = GUILayout.Button(text + plusMinus, GUILayout.ExpandWidth(true));
             GUILayout.EndHorizontal();
-            return x;
+            return buttonPressed;
         }
 
         public static bool DrawCollapseableButton(GUIContent content, bool isCollapsed, params GUILayoutOption[] options)
         {
-            GUILayout.BeginHorizontal(options);
-            string plusMinus = " [-]";
-            if (isCollapsed)
-            {
-                plusMinus = " [+]";
-            }
-            var x = GUILayout.Button(content + plusMinus, GUILayout.ExpandWidth(true));
-            GUILayout.EndHorizontal();
-            return x;
+            return DrawCollapseableButton(content.ToString(), isCollapsed, options);
         }
 
         public static bool DrawCurrentDropdown()

--- a/ConfigurationManager/SettingSearcher.cs
+++ b/ConfigurationManager/SettingSearcher.cs
@@ -21,7 +21,7 @@ namespace ConfigurationManager
 
         private static readonly Type _bepin4BaseSettingType = Type.GetType("BepInEx4.ConfigWrapper`1, BepInEx.BepIn4Patcher, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null", false);
 
-        public static void CollectSettings(out IEnumerable<SettingEntryBase> results, out List<string> modsWithoutSettings, bool showDebug)
+        public static void CollectSettings(out IEnumerable<SettingEntryBase> results, out List<string> modsWithoutSettings, bool showDebug, bool isCollapsed)
         {
             modsWithoutSettings = new List<string>();
 
@@ -67,7 +67,6 @@ namespace ConfigurationManager
                     enabledSetting.DispName = "!Allow plugin to run on every frame";
                     enabledSetting.Description = "Disabling this will disable some or all of the plugin's functionality.\nHooks and event-based functionality will not be disabled.\nThis setting will be lost after game restart.";
                     enabledSetting.IsAdvanced = true;
-                    enabledSetting.IsCollapsed = true;
                     detected.Add(enabledSetting);
                 }
 
@@ -77,6 +76,7 @@ namespace ConfigurationManager
                     if (isAdvancedPlugin)
                         detected.ForEach(entry => entry.IsAdvanced = true);
 
+                    detected.ForEach(entry => entry.IsCollapsed = isCollapsed);
                     results = results.Concat(detected);
                 }
             }

--- a/ConfigurationManager/SettingSearcher.cs
+++ b/ConfigurationManager/SettingSearcher.cs
@@ -67,7 +67,7 @@ namespace ConfigurationManager
                     enabledSetting.DispName = "!Allow plugin to run on every frame";
                     enabledSetting.Description = "Disabling this will disable some or all of the plugin's functionality.\nHooks and event-based functionality will not be disabled.\nThis setting will be lost after game restart.";
                     enabledSetting.IsAdvanced = true;
-                    enabledSetting.ShowSetting = true;
+                    enabledSetting.IsCollapsed = true;
                     detected.Add(enabledSetting);
                 }
 

--- a/ConfigurationManager/SettingSearcher.cs
+++ b/ConfigurationManager/SettingSearcher.cs
@@ -67,6 +67,7 @@ namespace ConfigurationManager
                     enabledSetting.DispName = "!Allow plugin to run on every frame";
                     enabledSetting.Description = "Disabling this will disable some or all of the plugin's functionality.\nHooks and event-based functionality will not be disabled.\nThis setting will be lost after game restart.";
                     enabledSetting.IsAdvanced = true;
+                    enabledSetting.ShowSetting = true;
                     detected.Add(enabledSetting);
                 }
 


### PR DESCRIPTION
 Added logic to ConfigurationManager and SettingFieldDrawer in order to make plugins collapsable in the GUI. Includes a configuration value to make plugins expanded or collapsed by default.