### PR TITLE
Fix F1 not hiding window again

### DIFF
--- a/ConfigurationManager/ConfigurationManager.cs
+++ b/ConfigurationManager/ConfigurationManager.cs
@@ -251,6 +251,12 @@ namespace ConfigurationManager
         {
             if (DisplayingWindow)
             {
+                if (Event.current.type == EventType.KeyUp && Event.current.keyCode == _keybind.Value.MainKey)
+                {
+                    DisplayingWindow = false;
+                    return;
+                }
+
                 SetUnlockCursor(0, true);
 
                 if (GUI.Button(_screenRect, string.Empty, GUI.skin.box) &&
@@ -606,7 +612,10 @@ namespace ConfigurationManager
 
             if (OverrideHotkey) return;
 
-            if (_keybind.Value.IsDown()) DisplayingWindow = !DisplayingWindow;
+            if (!DisplayingWindow && _keybind.Value.IsUp())
+            {
+                DisplayingWindow = true;
+            }
         }
 
         private void LateUpdate()


### PR DESCRIPTION
Currently, it's not possible to close the settings window again by pressing `F1`.

From what I can tell `Event` has existed at least since Unity version 5.4 but I'm not sure what your requirements for backward compatibility are. Otherwise, it might require some reflection or a version check.

Edit: Also, I checked the hotkey functionality and it's still possible to set hotkeys to `F1` without closing the window, although not sure why anybody would want to do that.