### PR TITLE
[WIP] Add background canvas to block clicks behind UI

### DIFF
--- a/ConfigurationManager/ConfigurationManager.cs
+++ b/ConfigurationManager/ConfigurationManager.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using BepInEx;
 using BepInEx.Logging;
 using UnityEngine;
+using UnityEngine.UI;
 using BepInEx.Configuration;
 
 namespace ConfigurationManager
@@ -70,6 +71,8 @@ namespace ConfigurationManager
         private int _previousCursorLockState;
         private bool _previousCursorVisible;
 
+        private GameObject _clickBlockerCanvas;
+
         internal static Texture2D TooltipBg { get; private set; }
         internal static Texture2D WindowBackground { get; private set; }
 
@@ -112,6 +115,7 @@ namespace ConfigurationManager
                 _displayingWindow = value;
 
                 SettingFieldDrawer.ClearCache();
+                BlockClicks(_displayingWindow);
 
                 if (_displayingWindow)
                 {
@@ -627,6 +631,31 @@ namespace ConfigurationManager
                     _curLockState.SetValue(null, lockState, null);
                 
                 _curVisible.SetValue(null, cursorVisible, null);
+            }
+        }
+
+        private void BlockClicks(bool value)
+        {
+            if (value)
+            {
+                _clickBlockerCanvas = new GameObject("BepInEx.ConfigurationManager Click Blocker", typeof(Canvas), typeof(GraphicRaycaster));
+                var canvas = _clickBlockerCanvas.GetComponent<Canvas>();
+                canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+                canvas.sortingOrder = Int16.MaxValue;
+                DontDestroyOnLoad(_clickBlockerCanvas);
+                var panel = new GameObject("Image", typeof(Image));
+                panel.transform.SetParent(_clickBlockerCanvas.transform);
+                var rect = panel.GetComponent<RectTransform>();
+                rect.anchorMin = new Vector2(0, 0);
+                rect.anchorMax = new Vector2(1, 1);
+                rect.offsetMin = Vector2.zero;
+                rect.offsetMax = Vector2.zero;
+                panel.GetComponent<Image>().color = new Color(0, 0, 0, 0.3f);
+            }
+            else
+            {
+                if (_clickBlockerCanvas)
+                    Destroy(_clickBlockerCanvas);
             }
         }
 

--- a/ConfigurationManager/ConfigurationManager.cs
+++ b/ConfigurationManager/ConfigurationManager.cs
@@ -634,9 +634,9 @@ namespace ConfigurationManager
             }
         }
 
-        private void BlockClicks(bool value)
+        private void BlockClicks(bool block)
         {
-            if (value)
+            if (block)
             {
                 _clickBlockerCanvas = new GameObject("BepInEx.ConfigurationManager Click Blocker", typeof(Canvas), typeof(GraphicRaycaster));
                 var canvas = _clickBlockerCanvas.GetComponent<Canvas>();
@@ -652,10 +652,8 @@ namespace ConfigurationManager
                 rect.offsetMax = Vector2.zero;
                 panel.GetComponent<Image>().color = new Color(0, 0, 0, 0.3f);
             }
-            else
-            {
-                if (_clickBlockerCanvas)
-                    Destroy(_clickBlockerCanvas);
+            else if (_clickBlockerCanvas) {
+                Destroy(_clickBlockerCanvas);
             }
         }
 


### PR DESCRIPTION
The Unity UI already blocks clicks for the most part but it doesn't work when the game is using Rewired for its input. In that case, clicking on the settings window also produces a click in the game and for example, can move a character in the background.

This PR adds a canvas behind the settings window that catches all clicks. I'm not sure if that's the best solution but it's what UnityModManager uses and it seems to work well.

The only issue left to solve is that this introduces a dependency on `UnityEngine.UI` (which is not yet added by the PR). I'm not sure if there are any issues regarding backward compatibility in that regard and also what the usual way to add the dependency would be. I guess you probably know more about that. I assume it would require adding a stripped version of the dll?