### PR TITLE
Preserve collapsing of plugins upon Settings rebuild

### DIFF
--- a/ConfigurationManager/ConfigurationManager.cs
+++ b/ConfigurationManager/ConfigurationManager.cs
@@ -58,7 +58,7 @@ namespace ConfigurationManager
         private string _modsWithoutSettings;
 
         private List<SettingEntryBase> _allSettings;
-        private List<PluginSettingsData> _filteredSetings;
+        private List<PluginSettingsData> _filteredSetings = new List<PluginSettingsData>();
 
         internal Rect SettingWindowRect { get; private set; }
         private Rect _screenRect;
@@ -153,11 +153,9 @@ namespace ConfigurationManager
                 SettingFieldDrawer.SettingDrawHandlers[settingType] = onGuiDrawer;
         }
 
-        private void BuildSettingList()
+        public void BuildSettingList()
         {
             SettingSearcher.CollectSettings(out var results, out var modsWithoutSettings, _showDebug);
-
-            //todo set collapsed state
 
             _modsWithoutSettings = string.Join(", ", modsWithoutSettings.Select(x => x.TrimStart('!')).OrderBy(x => x).ToArray());
             _allSettings = results.ToList();
@@ -197,6 +195,15 @@ namespace ConfigurationManager
 
             var settingsAreCollapsed = _pluginConfigCollapsedDefault.Value;
 
+            var nonDefaultCollpasingStateByPluginName = new HashSet<string>();
+            foreach (var pluginSetting in _filteredSetings)
+            {
+                if (pluginSetting.Collapsed != settingsAreCollapsed)
+                {
+                    nonDefaultCollpasingStateByPluginName.Add(pluginSetting.Info.Name);
+                }
+            }
+
             _filteredSetings = results
                 .GroupBy(x => x.PluginInfo)
                 .Select(pluginSettings =>
@@ -207,7 +214,7 @@ namespace ConfigurationManager
                         .ThenBy(x => x.Key)
                         .Select(x => new PluginSettingsData.PluginSettingsGroupData { Name = x.Key, Settings = x.OrderByDescending(set => set.Order).ThenBy(set => set.DispName).ToList() });
 
-                    return new PluginSettingsData { Info = pluginSettings.Key, Categories = categories.ToList(), Collapsed = settingsAreCollapsed };
+                    return new PluginSettingsData { Info = pluginSettings.Key, Categories = categories.ToList(), Collapsed = nonDefaultCollpasingStateByPluginName.Contains(pluginSettings.Key.Name) ? !settingsAreCollapsed : settingsAreCollapsed };
                 })
                 .OrderBy(x => x.Info.Name)
                 .ToList();


### PR DESCRIPTION
Implements the open TODO Item regarding collapsing (preserves display also for debug mode toggling for example).

Additionally exposes BuildSettingsList as public API so that Mods using it can refresh their display easily.

Closes #18.