### PR TITLE
Fix compatibility with BepInEx 5.4.10

### DIFF
--- a/ConfigurationManager/Utilities/Utilities.cs
+++ b/ConfigurationManager/Utilities/Utilities.cs
@@ -58,8 +58,8 @@ namespace ConfigurationManager.Utilities
             return false;
         }
 
-        // Search for objects instead of using chainloader API to find dynamically loaded plugins
-        public static BaseUnityPlugin[] FindPlugins() => Object.FindObjectsOfType(typeof(BaseUnityPlugin)).Cast<BaseUnityPlugin>().ToArray();
+        // Additionally search for BaseUnityPlugin to find dynamically loaded plugins
+        public static BaseUnityPlugin[] FindPlugins() => BepInEx.Bootstrap.Chainloader.Plugins.Concat(Object.FindObjectsOfType(typeof(BaseUnityPlugin)).Cast<BaseUnityPlugin>()).Distinct().ToArray();
 
         public static bool IsNumber(this object value) => value is sbyte
                    || value is byte


### PR DESCRIPTION
BepInEx 5.4.10 hides its plugins now via HideAndDontSave (see commit https://github.com/BepInEx/BepInEx/commit/0a25349ac442f2ff928f56545258c9cf7fba5d76), which causes any regularly loaded plugins to not be found with FindObjectsOfType() anymore.

Thus we now load the regularly loaded plugins from the BepInEx API and additionally include the dynamic plugins.

This is quite stupid currently as the ConfigurationManager finds exactly zero plugins right now (minus potential dynamically loaded ones). A quick merge and release would be appreciated.

Also note the `.Distinct()` in order to avoid it breaking with older BepInEx versions.