### PR TITLE
Fixed a bug that caused an exception if DLLs that failed to load were mixed in

### DIFF
--- a/ConfigurationManager/SettingSearcher.cs
+++ b/ConfigurationManager/SettingSearcher.cs
@@ -28,6 +28,7 @@ namespace ConfigurationManager
             // Have to use FindObjectsOfType(Type) instead of FindObjectsOfType<T> because the latter is not available in some older unity versions.
             // Still look inside Chainloader.PluginInfos in case the BepInEx_Manager GameObject uses HideFlags.HideAndDontSave, which hides it from Object.Find methods.
             return Chainloader.PluginInfos.Values.Select(x => x.Instance)
+                              .Where(plugin => plugin != null)
                               .Union(UnityEngine.Object.FindObjectsOfType(typeof(BaseUnityPlugin)).Cast<BaseUnityPlugin>())
                               .ToArray();
         }


### PR DESCRIPTION
Fixed a bug that caused an exception if DLLs that failed to load were mixed in.
The IL2CPP version was circumvented by the is operation.
Merge if it looks good.

```
NullReferenceException: Object reference not set to an instance of an object
  at ConfigurationManager.SettingSearcher.CollectSettings (IEnumerable`1& results, System.Collections.Generic.List`1& modsWithoutSettings, Boolean showDebug) [0x00000] in <filename unknown>:0 
  at ConfigurationManager.ConfigurationManager.BuildSettingList () [0x00000] in <filename unknown>:0 
  at ConfigurationManager.ConfigurationManager.set_DisplayingWindow (Boolean value) [0x00000] in <filename unknown>:0 
  at ConfigurationManagerWrapper.ConfigurationManagerWrapper.Update () [0x00000] in <filename unknown>:0 
 
(Filename:  Line: -1)
```

Occurred by installing KoikatsuSunshine DLL (KKS_AssetImport.dll) on Koikatu (KK).

An exception during list generation prevents the plugin list in ConfigurationManager from being generated.
![スクリーンショット 2024-02-28 221006](https://github.com/BepInEx/BepInEx.ConfigurationManager/assets/4230203/029925c9-6637-49d9-8efc-330f46b472e3)

