### PR TITLE
Do not throw ArgumenNullException in ConfigSettingEntry.GetAcceptedValues

### DIFF
--- a/ConfigurationManager.Shared/ConfigSettingEntry.cs
+++ b/ConfigurationManager.Shared/ConfigSettingEntry.cs
@@ -34,33 +34,13 @@ namespace ConfigurationManager
 
             var values = entry.Description?.AcceptableValues;
 
-            if (values != null && IsTypeSupported(values.GetType()))
+            if (values != null)
                 GetAcceptableValues(values);
 
             DefaultValue = entry.DefaultValue;
 
             SetFromAttributes(entry.Description?.Tags, owner);
         }
-
-        private bool IsTypeSupported(Type type)
-        {
-            foreach (var t in supportedTypes)
-                if (IsSubclassOfRawGeneric(t, type)) return true;
-            return false;
-        }
-
-        // Taken from https://stackoverflow.com/questions/457676/check-if-a-class-is-derived-from-a-generic-class
-        private static bool IsSubclassOfRawGeneric(Type generic, Type toCheck) {
-            while (toCheck != null && toCheck != typeof(object)) {
-                var cur = toCheck.IsGenericType ? toCheck.GetGenericTypeDefinition() : toCheck;
-                if (generic == cur) {
-                    return true;
-                }
-                toCheck = toCheck.BaseType;
-            }
-            return false;
-        }
-
         private void GetAcceptableValues(AcceptableValueBase values)
         {
             var t = values.GetType();
@@ -72,13 +52,12 @@ namespace ConfigurationManager
             else
             {
                 var minProp = t.GetProperty(nameof(AcceptableValueRange<bool>.MinValue), BindingFlags.Instance | BindingFlags.Public);
-                if (minProp != null)
+                var maxProp = t.GetProperty(nameof(AcceptableValueRange<bool>.MaxValue), BindingFlags.Instance | BindingFlags.Public);
+                if (minProp != null && maxProp != null)
                 {
-                    var maxProp = t.GetProperty(nameof(AcceptableValueRange<bool>.MaxValue), BindingFlags.Instance | BindingFlags.Public);
-                    if (maxProp == null) throw new ArgumentNullException(nameof(maxProp));
                     AcceptableValueRange = new KeyValuePair<object, object>(minProp.GetValue(values, null), maxProp.GetValue(values, null));
                     ShowRangeAsPercent = (AcceptableValueRange.Key.Equals(0) || AcceptableValueRange.Key.Equals(1)) && AcceptableValueRange.Value.Equals(100) ||
-                                         AcceptableValueRange.Key.Equals(0f) && AcceptableValueRange.Value.Equals(1f);
+                                            AcceptableValueRange.Key.Equals(0f) && AcceptableValueRange.Value.Equals(1f);
                 }
             }
         }

--- a/ConfigurationManager.Shared/ConfigSettingEntry.cs
+++ b/ConfigurationManager.Shared/ConfigSettingEntry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -14,7 +14,6 @@ namespace ConfigurationManager
 {
     internal sealed class ConfigSettingEntry : SettingEntryBase
     {
-        private readonly Type[] supportedTypes = { typeof(AcceptableValueList<>), typeof(AcceptableValueRange<>)};
         public ConfigEntryBase Entry { get; }
 
         public ConfigSettingEntry(ConfigEntryBase entry, BaseUnityPlugin owner)
@@ -33,7 +32,6 @@ namespace ConfigurationManager
             }
 
             var values = entry.Description?.AcceptableValues;
-
             if (values != null)
                 GetAcceptableValues(values);
 
@@ -41,6 +39,7 @@ namespace ConfigurationManager
 
             SetFromAttributes(entry.Description?.Tags, owner);
         }
+
         private void GetAcceptableValues(AcceptableValueBase values)
         {
             var t = values.GetType();
@@ -57,7 +56,7 @@ namespace ConfigurationManager
                 {
                     AcceptableValueRange = new KeyValuePair<object, object>(minProp.GetValue(values, null), maxProp.GetValue(values, null));
                     ShowRangeAsPercent = (AcceptableValueRange.Key.Equals(0) || AcceptableValueRange.Key.Equals(1)) && AcceptableValueRange.Value.Equals(100) ||
-                                            AcceptableValueRange.Key.Equals(0f) && AcceptableValueRange.Value.Equals(1f);
+                                         AcceptableValueRange.Key.Equals(0f) && AcceptableValueRange.Value.Equals(1f);
                 }
             }
         }


### PR DESCRIPTION
This PR removes the `ArgumenNullException` present in [`ConfigSettingEntry.GetAcceptedValues(AcceptableValueBase values)`](../blob/a6c7d75566b6df411db90e04277ad1bd96231799/ConfigurationManager.Shared/ConfigSettingEntry.cs#L43), enforcing the use of both `MinValue` and `MaxValue` for custom range classes (see  issue's comments for a in-depth explanation)