### PR TITLE
Order Categories by Numeric Prefix

### DIFF
--- a/ConfigurationManager.Shared/ConfigurationManager.cs
+++ b/ConfigurationManager.Shared/ConfigurationManager.cs
@@ -11,6 +11,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using UnityEngine;
 
 #if IL2CPP
@@ -241,6 +242,7 @@ namespace ConfigurationManager
                     var categories = pluginSettings
                         .GroupBy(eb => eb.Category)
                         .OrderBy(x => string.Equals(x.Key, shortcutsCatName, StringComparison.Ordinal))
+                        .ThenBy(x => IntPrefixOrder(x.Key))
                         .ThenBy(x => x.Key)
                         .Select(x => new PluginSettingsData.PluginSettingsGroupData { Name = x.Key, Settings = x.OrderByDescending(set => set.Order).ThenBy(set => set.DispName).ToList() });
 
@@ -256,6 +258,13 @@ namespace ConfigurationManager
                 })
                 .OrderBy(x => x.Info.Name)
                 .ToList();
+        }
+
+        private static int IntPrefixOrder(string name)
+        {
+            // match integer prefix at the start of the string
+            Match match = Regex.Match(name, @"^\d+");
+            return match.Success ? int.Parse(match.Value) : int.MaxValue;
         }
 
         private static bool IsKeyboardShortcut(SettingEntryBase x)


### PR DESCRIPTION
In many mods, categories are prefixed with numbers to control their order. However, since sorting is done lexical, numbers greater than 10 are not ordered intuitively. E.g. "10" comes before "2".

This PR improves category sorting by extracting numeric prefixes and sorting them numerically before applying a lexical sort. Categories without a numeric prefix remain unaffected. Categories with the same number prefix are still sorted lexical.

For example, instead of:
```
1 - First Category
10 - Tenth Category
2 - Second Category
...
```

They are now ordered:
```
1 - First Category
2 - Second Category
...
10 - Tenth Category
```