### PR TITLE
Add SectionOrder to Config Entries

### DIFF
--- a/ConfigurationManager.Shared/ConfigurationManager.cs
+++ b/ConfigurationManager.Shared/ConfigurationManager.cs
@@ -239,10 +239,11 @@ namespace ConfigurationManager
                 .Select(pluginSettings =>
                 {
                     var categories = pluginSettings
-                        .GroupBy(eb => eb.Category)
-                        .OrderBy(x => string.Equals(x.Key, shortcutsCatName, StringComparison.Ordinal))
-                        .ThenBy(x => x.Key)
-                        .Select(x => new PluginSettingsData.PluginSettingsGroupData { Name = x.Key, Settings = x.OrderByDescending(set => set.Order).ThenBy(set => set.DispName).ToList() });
+                        .GroupBy(eb => new { eb.SectionOrder, eb.Category })
+                        .OrderBy(x => string.Equals(x.Key.Category, shortcutsCatName, StringComparison.Ordinal))
+                        .ThenByDescending(x => x.Key.SectionOrder)
+                        .ThenBy(x => x.Key.Category)
+                        .Select(x => new PluginSettingsData.PluginSettingsGroupData { Name = x.Key.Category, Settings = x.OrderByDescending(set => set.Order).ThenBy(set => set.DispName).ToList() });
 
                     var website = Utils.GetWebsite(pluginSettings.First().PluginInstance);
 

--- a/ConfigurationManager.Shared/SettingEntryBase.cs
+++ b/ConfigurationManager.Shared/SettingEntryBase.cs
@@ -120,6 +120,12 @@ namespace ConfigurationManager
         public int Order { get; protected set; }
 
         /// <summary>
+        /// Order of the section in the settings list relative to other sections. 0 by default, lower is higher on the list.
+        /// Sections with the same name but different <see cref="SectionOrder"/> values will be treated as separate sections.
+        /// </summary>
+        public int SectionOrder { get; protected set; }
+
+        /// <summary>
         /// Get the value of this setting
         /// </summary>
         public abstract object Get();

--- a/ConfigurationManagerAttributes.cs
+++ b/ConfigurationManagerAttributes.cs
@@ -128,6 +128,13 @@ internal sealed class ConfigurationManagerAttributes
     public int? Order;
 
     /// <summary>
+    /// Order of the section in the settings list relative to other sections.
+    /// 0 by default, lower is higher on the list.
+    /// Sections with the same name but different <see cref="SectionOrder"/> values will be treated as separate sections.
+    /// </summary>
+    public int? SectionOrder;
+
+    /// <summary>
     /// Only show the value, don't allow editing it.
     /// </summary>
     public bool? ReadOnly;


### PR DESCRIPTION
Suspends #100

This adds the possible new field `SectionOrder` to `ConfigurationManagerAttributes`.
Sections are grouped by both their order and name, with SectionOrder taking precedence. Thus, sections with the same name but different SectionOrder values will be treated as separate sections.

For example:
```cs
Config.Bind("1 - General", "Enable", true, new ConfigDescription("", null, new ConfigurationManagerAttributes { SectionOrder = 1000 - 1 }));
Config.Bind("2 - General", "Enable", true, new ConfigDescription("", null, new ConfigurationManagerAttributes { SectionOrder = 1000 - 2 }));
Config.Bind("3 - General", "Enable", true, new ConfigDescription("", null, new ConfigurationManagerAttributes { SectionOrder = 1000 - 3 }));
Config.Bind("10 - General", "Enable1", true, new ConfigDescription("", null, new ConfigurationManagerAttributes { SectionOrder = 1000 - 10 }));
Config.Bind("10 - General", "Enable2", true, new ConfigDescription("", null, new ConfigurationManagerAttributes { SectionOrder = 1000 - 10 }));
Config.Bind("10 - General", "Enable3", true, new ConfigDescription("", null, new ConfigurationManagerAttributes { SectionOrder = 1000 - 11 }));
```

Will be rendered as:
![grafik](https://github.com/user-attachments/assets/e36e4570-af42-4456-92c3-31ed36aa1bca)

