### PR TITLE
Fixed decimal for Scandinavia and similar.

### DIFF
--- a/ConfigurationManager.Shared/Utilities/Utilities.cs
+++ b/ConfigurationManager.Shared/Utilities/Utilities.cs
@@ -39,6 +39,8 @@ namespace ConfigurationManager.Utilities
 
         public static string AppendZero(this string s)
         {
+            // Scandinavian and some other regions use Comma (,) instead of Period (.) for decimal places. This causes some issues, so this fixes it.
+            s = s.Replace(",", ".");
             return !s.Contains(".") ? s + ".0" : s;
         }
 


### PR DESCRIPTION
Scandinavian and some other regions use Comma (,) instead of Period (.) for decimal places.
This causes some issues when entering float values, by the values going haywire and jumping all over the place.
![image](https://github.com/user-attachments/assets/792a5d7d-2269-40fe-aad2-047ade236e79)
This simple fix just replaces the comma with a period and seems to fix the issue.

**NOTE:** I have only tried this with Danish Culture, so there might be some issue with other cultures I haven't happened upon.