### PR TITLE
Catch exceptions during settings search

### DIFF
--- a/ConfigurationManager/SettingSearcher.cs
+++ b/ConfigurationManager/SettingSearcher.cs
@@ -6,6 +6,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using BepInEx.Bootstrap;
+using UnityEngine;
 
 namespace ConfigurationManager
 {
@@ -49,39 +50,48 @@ namespace ConfigurationManager
 
             foreach (var plugin in FindPlugins())
             {
-                var type = plugin.GetType();
-
-                var pluginInfo = plugin.Info.Metadata;
-                var pluginName = pluginInfo?.Name ?? plugin.GetType().FullName;
-
-                if (type.GetCustomAttributes(typeof(BrowsableAttribute), false).Cast<BrowsableAttribute>()
-                        .Any(x => !x.Browsable))
+                try
                 {
-                    modsWithoutSettings.Add(pluginName);
-                    continue;
+                    var type = plugin.GetType();
+
+                    var pluginInfo = plugin.Info.Metadata;
+                    var pluginName = pluginInfo?.Name ?? plugin.GetType().FullName;
+
+                    if (type.GetCustomAttributes(typeof(BrowsableAttribute), false).Cast<BrowsableAttribute>()
+                            .Any(x => !x.Browsable))
+                    {
+                        modsWithoutSettings.Add(pluginName);
+                        continue;
+                    }
+
+                    var detected = new List<SettingEntryBase>();
+
+                    detected.AddRange(GetPluginConfig(plugin).Cast<SettingEntryBase>());
+
+                    detected.RemoveAll(x => x.Browsable == false);
+
+                    if (detected.Count == 0)
+                        modsWithoutSettings.Add(pluginName);
+
+                    // Allow to enable/disable plugin if it uses any update methods ------
+                    if (showDebug && type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Any(x => _updateMethodNames.Contains(x.Name)))
+                    {
+                        var enabledSetting = new PropertySettingEntry(plugin, type.GetProperty("enabled"), plugin);
+                        enabledSetting.DispName = "!Allow plugin to run on every frame";
+                        enabledSetting.Description = "Disabling this will disable some or all of the plugin's functionality.\nHooks and event-based functionality will not be disabled.\nThis setting will be lost after game restart.";
+                        enabledSetting.IsAdvanced = true;
+                        detected.Add(enabledSetting);
+                    }
+
+                    if (detected.Count > 0)
+                        results = results.Concat(detected);
                 }
-
-                var detected = new List<SettingEntryBase>();
-
-                detected.AddRange(GetPluginConfig(plugin).Cast<SettingEntryBase>());
-
-                detected.RemoveAll(x => x.Browsable == false);
-
-                if (detected.Count == 0)
-                    modsWithoutSettings.Add(pluginName);
-
-                // Allow to enable/disable plugin if it uses any update methods ------
-                if (showDebug && type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Any(x => _updateMethodNames.Contains(x.Name)))
+                catch (Exception ex)
                 {
-                    var enabledSetting = new PropertySettingEntry(plugin, type.GetProperty("enabled"), plugin);
-                    enabledSetting.DispName = "!Allow plugin to run on every frame";
-                    enabledSetting.Description = "Disabling this will disable some or all of the plugin's functionality.\nHooks and event-based functionality will not be disabled.\nThis setting will be lost after game restart.";
-                    enabledSetting.IsAdvanced = true;
-                    detected.Add(enabledSetting);
+                    string pluginName = plugin?.Info?.Metadata?.Name ?? plugin?.GetType().FullName;
+                    ConfigurationManager.Logger.LogError($"Failed to collect settings of the following plugin: {pluginName}");
+                    ConfigurationManager.Logger.LogError(ex);
                 }
-
-                if (detected.Count > 0)
-                    results = results.Concat(detected);
             }
         }
 


### PR DESCRIPTION
If during the settings search an exception occurs, no settings are collected and thus displayed. Now it catches these exception and logs for what plugin this happened.